### PR TITLE
Fix heading text typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,7 +371,7 @@ a trabajar con otros. Espero más talleres!!!</p>
             </div>
             <!--seccion form-->
             <div class="seccion-form">
-                <h1>Inscripciónes </h1>
+                <h1>Inscripciones</h1>
                 <p>Mediante este formulario podrás hacer una solicitud para utilizar el espacio PIAC.</p>
                 <p>Una vez completado, nos contactaremos contigo mediante correo electrónico</p>
                 <p>para confirmar la reserva.</p>


### PR DESCRIPTION
## Summary
- correct "Inscripciónes" to "Inscripciones" in the sign-up section

## Testing
- `grep -n Inscripciones index.html`

------
https://chatgpt.com/codex/tasks/task_e_686427da3ec08321ab4b3da9946968de